### PR TITLE
Feature/update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ billiard==3.5.0.3
 celery==4.2.0
 cffi==1.14.5
 cryptography>=2.3
-Django==2.2.17
+Django==3.1.7
 django-bootstrap4==0.0.6
 django-celery-results==1.0.1
 django-filter==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ asn1crypto==0.24.0
 bcrypt==3.1.4
 billiard==3.5.0.3
 celery==4.2.0
-cffi==1.11.5
+cffi==1.14.5
 cryptography>=2.3
 Django==2.2.17
 django-bootstrap4==0.0.6
@@ -13,7 +13,6 @@ django-pam==2.0.0
 django-tables2==1.21.2
 et-xmlfile==1.0.1
 fabric==2.1.3
-freeze==1.0.10
 gunicorn==19.8.1
 idna==2.7
 invoke==1.0.0
@@ -23,6 +22,7 @@ lml==0.0.1
 lxml==4.6.2
 openpyxl==2.5.3
 paramiko==2.4.2
+pretty_dump==3.0
 psycopg2==2.7.5
 pyasn1==0.4.3
 pycparser==2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ celery==4.2.0
 cffi==1.14.5
 cryptography>=2.3
 Django==3.1.7
-django-bootstrap4==0.0.6
+django-bootstrap4==2.3.1
 django-celery-results==1.0.1
-django-filter==2.0.0
+django-filter==2.4.0
 django-pam==2.0.0
-django-tables2==1.21.2
+django-tables2==2.3.4
 et-xmlfile==1.0.1
 fabric==2.1.3
 gunicorn==19.8.1
@@ -35,7 +35,6 @@ pyexcel-xlsx==0.5.6
 PyNaCl==1.2.1
 python-pam==1.8.4
 pytz==2018.3
-six==1.11.0
 texttable==1.2.1
 vine==1.1.4
 xlrd==1.1.0


### PR DESCRIPTION
This update gets BIL submit portal up to the most recent Django version, along with all other broken dependencies.
- [x] cffi==1.14.5
- [x] Django==3.1.7
- [x] django-bootstrap4==2.3.1
- [x] django-filter==2.4.0
- [x] django-tables2==2.3.4
- [x] freeze==1.0.10 --->  pretty_dump==3.0
- [x] removed six==1.11.0
- [x] tested userflow of sign in
- [x] tested userflow of submit collection
- [x] tested userflow of submit metadata
- [x] tested userflow of submit for validation (worked up til email send, which is fine because it wasn't configured)