### PR TITLE
move is_bil_admin from projectpeople to people

### DIFF
--- a/ingest/models.py
+++ b/ingest/models.py
@@ -328,18 +328,16 @@ class People(models.Model):
     affiliation = models.CharField(max_length=256)
     affiliation_identifier = models.CharField(max_length=256)
     auth_user_id = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null = True, blank=True)
-   
-class ProjectPeople(models.Model):
- 
+    is_bil_admin = models.BooleanField(default=False)
+  
+class ProjectPeople(models.Model): 
     project_id = models.ForeignKey(Project, on_delete=models.CASCADE, null=True, blank=True)
     people_id = models.ForeignKey(People, on_delete=models.SET_NULL, null = True, blank=True)
     is_pi = models.BooleanField(default=False)
     is_po = models.BooleanField(default=False)
     doi_role = models.CharField(max_length=256)
-    is_bil_admin = models.BooleanField(default=False)
 
 class Funder(models.Model):
-
     name = models.CharField(max_length=256)
     funding_reference_identifier = models.CharField(max_length=256)
     funding_reference_identifier_type = models.CharField(max_length=256)
@@ -348,7 +346,6 @@ class Funder(models.Model):
     grant_number = models.CharField(max_length=256)
 
 class ProjectFunders(models.Model):
-
     project_id = models.ForeignKey(Project, on_delete=models.CASCADE, null=True, blank=True)
     funder_id = models.ForeignKey(Funder, on_delete=models.CASCADE, null=True, blank=True)
 
@@ -360,6 +357,3 @@ class EventsLog(models.Model):
     timestamp = models.DateTimeField()
     event_type = models.CharField(max_length=64, default="", choices=[('mail_tapes_to_bil', 'Mail Tapes To BIL'), ('tapes_received', 'Tapes Received'), ('tapes_ready_for_qc', 'Tapes Ready For QC'), ('move_to_collection', 'Move To Collection'), ('request_brainball', 'Request Brainball'), ('Mail_brainball_from_bil', 'Mail Brainball From BIL'), ('mail_brainball_to_bil', 'Mail Brainball To BIL'), ('received_brainball', 'Received Brainball'), ('collection_created', 'Collection Created'), ('metadata_uploaded', 'Metadata Uploaded'), ('request_validation', 'Request Validation'), ('request_submission', 'Request Submission'), ('request_embargo', 'Request Embargo'), ('collection_public', 'Collection Public'), ('request_withdrawal', 'Request Withdrawal')])
 
-#class CollectionGroup(models.Model):
-#    project_id = models.ForeignKey(Project, on_delete = models.SET_NULL, null = True, blank=True)
-#    name = models.CharField(max_length = 256)


### PR DESCRIPTION
this PR moves the `is_bil_admin` column from the ProjectPeople table to the People table, as you cannot be a bil_admin on a per-project basis.