### PR TITLE
dependabot updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ asgiref==3.5.2
 asn1crypto==0.24.0
 bcrypt==3.1.4
 beautifulsoup4==4.9.3
-billiard<5.0
-celery<6.0
+billiard==3.6.4.0
+celery==5.2.7
 cffi==1.14.5
 click==8.0.3
 click-didyoumean==0.3.0
@@ -25,7 +25,7 @@ idna==2.7
 importlib-metadata==2.1.1
 invoke==1.0.0
 jdcal==1.4
-kombu<6.0
+kombu==5.2.4
 lml==0.0.1
 lxml==4.9.1
 openpyxl==2.5.3
@@ -33,6 +33,7 @@ paramiko==2.10.1
 pretty-dump==3.0
 prompt-toolkit==3.0.24
 psycopg==3.0.11
+psycopg2==2.9.5
 pyasn1==0.4.6
 pycparser==2.18
 pyexcel==0.5.8


### PR DESCRIPTION
Bump sqlparse from 0.4.2 to 0.4.4
Bump cryptography from 3.3.2 to 39.0.1
Bump django-celery-results from 2.0.0 to 2.4.0
Bump lxml from 4.6.5 to 4.9.1
