### PR TITLE
add brain initiative flag to projects

### DIFF
--- a/ingest/models.py
+++ b/ingest/models.py
@@ -17,6 +17,7 @@ class Project(models.Model):
     name = models.CharField(max_length=256, default="Project Name")
     funded_by = models.CharField(max_length=256)
     is_biccn = models.BooleanField(default=False)
+    is_brain_initiative = models.BooleanField(default=False)
 
 class Consortium(models.Model):
     short_name = models.CharField(max_length=256)
@@ -41,6 +42,7 @@ class People(models.Model):
     affiliation = models.CharField(max_length=256)
     affiliation_identifier = models.CharField(max_length=256)
     is_bil_admin = models.BooleanField(default=False)
+    has_reviewed_brain_initiative = models.BooleanField(default=False)
     auth_user_id = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.SET_NULL, null = True, blank=True)
 
 class Collection(models.Model):

--- a/ingest/static/ingest/createproject.js
+++ b/ingest/static/ingest/createproject.js
@@ -1,16 +1,16 @@
 function create_new_project() {
     const csrftoken = Cookies.get('csrftoken');
     const output_rows = [];
-    
+
     const name = document.getElementById("name");
     const funded_by = document.getElementById("funded_by");
+    const is_brain_initiative = document.getElementById("is_brain_initiative").checked;
     const consortia_ids = [];
     let parent_project;
 
     let options = document.getElementsByTagName('select')[0]
     for (let i=0, length=options.length; i<length; i++) {
         let opt = options[i];
-
         if (opt.selected) {
             consortia_ids.push(opt.value);
         }
@@ -19,7 +19,6 @@ function create_new_project() {
     let parent_project_options = document.getElementsByTagName('select')[1]
     for (let i=0, length=parent_project_options.length; i<length; i++) {
         let opt = parent_project_options[i];
-
         if (opt.selected) {
             parent_project = opt.value;
         }
@@ -29,31 +28,31 @@ function create_new_project() {
         "name": name.value,
         "funded_by": funded_by.value,
         "consortia_ids": consortia_ids,
-        "parent_project": parent_project
-        })     
-                
-            
-  fetch(`${window.origin}/ingest/create_project/`, {
-       method: "POST",
-       credentials: "include",
-       body: JSON.stringify(output_rows),
-       cache: "no-cache",
-       headers: new Headers({
-           "X-CSRFToken": csrftoken,
-           "content-type": "application/json"
-       })
-   })
-       .then(function(response) {
-           if (response.status !== 200) {
-               console.log('Looks like there was a problem. Status code: ${response.status}');
-               return;
-           }
-               response.json().then(function(data) {
-               console.log(data);
-               window.location.replace(data['url']);
-           });
-       })
-       .catch(function(error) {
-           console.log("Fetch error: " + error);
-       });
+        "parent_project": parent_project,
+        "is_brain_initiative": is_brain_initiative
+    });
+
+    fetch(`${window.origin}/ingest/create_project/`, {
+        method: "POST",
+        credentials: "include",
+        body: JSON.stringify(output_rows),
+        cache: "no-cache",
+        headers: new Headers({
+            "X-CSRFToken": csrftoken,
+            "content-type": "application/json"
+        })
+    })
+    .then(function(response) {
+        if (response.status !== 200) {
+            console.log('Looks like there was a problem. Status code: ${response.status}');
+            return;
+        }
+        response.json().then(function(data) {
+            console.log(data);
+            window.location.replace(data['url']);
+        });
+    })
+    .catch(function(error) {
+        console.log("Fetch error: " + error);
+    });
 }

--- a/ingest/tables.py
+++ b/ingest/tables.py
@@ -127,7 +127,7 @@ class CollectionTable(tables.Table):
             elif record.submission_status == 'PENDING':
                 return mark_safe(
                     '<span class="badge text-bg-warning px-2 py-1">'
-                    '<i class="fa-solid fa-clock me-1"></i>Pub. In Progress</span>'
+                    '<i class="fa-solid fa-clock me-1"></i>Validation Requested</span>'
                 )
             elif record.submission_status == 'FAILED':
                 return mark_safe(
@@ -147,7 +147,7 @@ class CollectionTable(tables.Table):
                     if already_requested:
                         return mark_safe(
                             '<span class="badge text-bg-warning px-2 py-1">'
-                            '<i class="fa-solid fa-clock me-1"></i>Pub. In Progress</span>'
+                            '<i class="fa-solid fa-clock me-1"></i>Validation Requested</span>'
                         )
                     return mark_safe(
                         '<a href="{}" class="btn btn-sm btn-outline-secondary">'
@@ -170,7 +170,7 @@ class CollectionTable(tables.Table):
                 if already_requested:
                     return mark_safe(
                         '<span class="badge text-bg-warning px-2 py-1">'
-                        '<i class="fa-solid fa-clock me-1"></i>Pub. In Progress</span>'
+                        '<i class="fa-solid fa-clock me-1"></i>Validation Requested</span>'
                     )
                 return mark_safe(
                     '<a href="{}" class="btn btn-sm btn-outline-secondary">'

--- a/ingest/templates/ingest/bil_index.html
+++ b/ingest/templates/ingest/bil_index.html
@@ -11,6 +11,7 @@
     </div>
   </div>
 
+  {% if show_stats %}
   <!-- Public dataset counter + bar chart -->
   <div class="card shadow-sm mb-4" style="border-top: 3px solid #161b33; background: linear-gradient(135deg, #161b33 0%, #2a3254 100%); color: #fff; border-radius: 8px;">
     <div class="card-body py-4 px-5">
@@ -42,6 +43,7 @@
       </div>
     </div>
   </div>
+  {% endif %}
 
   <div class="row g-4">
     <div class="col-lg-6">

--- a/ingest/templates/ingest/index.html
+++ b/ingest/templates/ingest/index.html
@@ -297,6 +297,7 @@ h1,h2,h3,h4,h5,h6 { font-family: 'Lato', sans-serif !important; }
 
   {% if request.user.username %}
 
+  {% if show_stats %}
   <!-- Instrument panel -->
   <div class="bil-instrument bil-fadein">
     <div class="bil-instrument-body">
@@ -338,6 +339,7 @@ h1,h2,h3,h4,h5,h6 { font-family: 'Lato', sans-serif !important; }
       </div>
     </div>
   </div>
+  {% endif %}
 
   <!-- Your Contributions -->
   {% if user_public_collections or user_public_datasets or user_validation_requested %}

--- a/ingest/templates/ingest/manage_projects.html
+++ b/ingest/templates/ingest/manage_projects.html
@@ -110,6 +110,7 @@
           <th>Consortia</th>
           <th>Parent Project</th>
           <th>Child Projects</th>
+          <th>Brain Initiative</th>
           <th class="text-center">Personnel</th>
           <th class="text-center">Submissions</th>
         </tr>
@@ -132,6 +133,13 @@
           <td>{{ project.parent_project_names|default:"—" }}</td>
           <td>{{ project.child_project_names|default:"—" }}</td>
           <td class="text-center">
+            <input type="checkbox"
+                   class="bi-toggle"
+                   data-toggle-url="{% url 'ingest:toggle_brain_initiative' project.id %}"
+                   {% if project.is_brain_initiative %}checked{% endif %}
+                   style="width:1.1rem;height:1.1rem;cursor:pointer;accent-color:var(--bil-accent);">
+          </td>
+          <td class="text-center">
             <a href="{% url 'ingest:view_project_people' project.id %}" class="bil-action-btn">
               <i class="fa-solid fa-users fa-xs"></i>Personnel
             </a>
@@ -144,7 +152,7 @@
         </tr>
         {% empty %}
         <tr class="bil-empty-row">
-          <td colspan="7">
+          <td colspan="8">
             <i class="fa-solid fa-diagram-project fa-lg d-block mb-2 mx-auto" style="color:rgba(22,27,51,.15);"></i>
             No projects found
           </td>
@@ -154,5 +162,29 @@
     </table>
   </div>
 </div>
+
+<script>
+(function () {
+  function getCsrf() {
+    return document.cookie.split(';').reduce(function (v, c) {
+      var p = c.trim().split('=');
+      return p[0] === 'csrftoken' ? decodeURIComponent(p[1]) : v;
+    }, '');
+  }
+
+  document.querySelectorAll('.bi-toggle').forEach(function (cb) {
+    cb.addEventListener('change', function () {
+      fetch(cb.dataset.toggleUrl, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'X-CSRFToken': getCsrf(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_brain_initiative: cb.checked })
+      }).then(function (r) {
+        if (!r.ok) { cb.checked = !cb.checked; }
+      }).catch(function () { cb.checked = !cb.checked; });
+    });
+  });
+})();
+</script>
 
 {% endblock %}

--- a/ingest/templates/ingest/pi_index.html
+++ b/ingest/templates/ingest/pi_index.html
@@ -127,6 +127,7 @@ h1,h2,h3,h4,h5,h6 { font-family: 'Lato', sans-serif !important; }
     <p>Manage your projects, submissions, and project users.</p>
   </div>
 
+  {% if show_stats %}
   <div class="bil-instrument bil-fadein">
     <div class="bil-instrument-body">
       <div class="d-flex align-items-center flex-wrap">
@@ -156,6 +157,7 @@ h1,h2,h3,h4,h5,h6 { font-family: 'Lato', sans-serif !important; }
       </div>
     </div>
   </div>
+  {% endif %}
 
   {% if user_public_collections or user_public_datasets or user_validation_requested %}
   <div class="bil-fadein" style="margin-bottom:1.5rem;">
@@ -262,6 +264,59 @@ h1,h2,h3,h4,h5,h6 { font-family: 'Lato', sans-serif !important; }
   </div>
 
 </div>
+
+{% if show_brain_initiative_modal %}
+<div class="modal fade" id="brainInitiativeModal" tabindex="-1"
+     data-bs-backdrop="static" data-bs-keyboard="false"
+     aria-labelledby="brainInitiativeModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content" style="border-radius:12px;border:1.5px solid rgba(22,27,51,.09);">
+      <div class="modal-header" style="border-bottom:1px solid rgba(22,27,51,.07);padding:1.25rem 1.5rem;">
+        <h5 class="modal-title" id="brainInitiativeModalLabel"
+            style="font-family:'Lato',sans-serif;font-weight:800;color:#161b33;font-size:1.05rem;">
+          <i class="fa-solid fa-brain me-2" style="color:var(--bil-accent);"></i>BRAIN Initiative Data Review
+        </h5>
+      </div>
+      <div class="modal-body" style="padding:1.5rem;">
+        <p style="font-family:'Lato',sans-serif;font-size:.875rem;color:#4a5070;margin-bottom:1.25rem;">
+          The Brain Image Library is now tracking which projects contain
+          <strong>BRAIN Initiative</strong>–funded data. Please review your projects below
+          and check any that include BRAIN Initiative data.
+        </p>
+        <div id="bi-project-list">
+          {% for proj in pi_projects %}
+          <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox"
+                   id="bi-proj-{{ proj.id }}"
+                   data-project-id="{{ proj.id }}"
+                   {% if proj.is_brain_initiative %}checked{% endif %}>
+            <label class="form-check-label" for="bi-proj-{{ proj.id }}"
+                   style="font-family:'Lato',sans-serif;font-size:.875rem;color:#161b33;">
+              {{ proj.name }}
+            </label>
+          </div>
+          {% empty %}
+          <p style="font-family:'Lato',sans-serif;font-size:.82rem;color:#8e92aa;">No projects found.</p>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="modal-footer" style="border-top:1px solid rgba(22,27,51,.07);padding:1rem 1.5rem;gap:.5rem;">
+        <button type="button" id="bi-remind-later"
+                style="background:#fff;color:#4a5070;border:1.5px solid rgba(22,27,51,.15);border-radius:7px;
+                       font-family:'Lato',sans-serif;font-weight:600;font-size:.8rem;padding:.45rem 1rem;cursor:pointer;">
+          Remind Me Later
+        </button>
+        <button type="button" id="bi-save-continue"
+                style="background:#161b33;color:#fff;border:none;border-radius:7px;
+                       font-family:'Lato',sans-serif;font-weight:600;font-size:.8rem;padding:.45rem 1rem;cursor:pointer;
+                       display:inline-flex;align-items:center;gap:6px;">
+          <i class="fa-solid fa-floppy-disk fa-xs"></i>Save &amp; Continue
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
 {% endblock %}
 
 {% block extra_scripts %}
@@ -332,4 +387,34 @@ h1,h2,h3,h4,h5,h6 { font-family: 'Lato', sans-serif !important; }
   chartEl.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) { new bootstrap.Tooltip(el); });
 })();
 </script>
+{% if show_brain_initiative_modal %}
+<script>
+(function () {
+  var modalEl = document.getElementById('brainInitiativeModal');
+  var modal = new bootstrap.Modal(modalEl);
+  modal.show();
+
+  document.getElementById('bi-remind-later').addEventListener('click', function () {
+    modal.hide();
+  });
+
+  document.getElementById('bi-save-continue').addEventListener('click', function () {
+    var csrftoken = document.cookie.split(';').reduce(function (v, c) {
+      var p = c.trim().split('=');
+      return p[0] === 'csrftoken' ? decodeURIComponent(p[1]) : v;
+    }, '');
+    var payload = {};
+    document.querySelectorAll('#bi-project-list input[type="checkbox"]').forEach(function (cb) {
+      payload[cb.dataset.projectId] = cb.checked;
+    });
+    fetch("{% url 'ingest:review_brain_initiative' %}", {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'X-CSRFToken': csrftoken, 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    }).then(function (r) { return r.json(); }).then(function () { modal.hide(); }).catch(function () { modal.hide(); });
+  });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/ingest/templates/ingest/project_form.html
+++ b/ingest/templates/ingest/project_form.html
@@ -126,6 +126,14 @@
               <input type="text" class="form-control" id="funded_by" name="funded_by" placeholder="Grant number" autocomplete="off">
             </div>
           </div>
+          <div class="mt-3">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" id="is_brain_initiative" name="is_brain_initiative">
+              <label class="form-check-label" for="is_brain_initiative" style="font-family:'Lato',sans-serif;font-size:.875rem;color:#4a5070;">
+                This project contains <strong>BRAIN Initiative</strong> data
+              </label>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/ingest/tests.py
+++ b/ingest/tests.py
@@ -14,10 +14,13 @@ Run with:
   python manage.py test ingest.tests.CheckContributorsSheetTests
 """
 
+import json
 import os
 import tempfile
 import xlwt
-from django.test import TestCase
+from django.test import TestCase, Client
+from django.contrib.auth.models import User
+from .models import Project, People, ProjectPeople, Consortium
 
 from ingest.views import (
     check_contributors_sheet,
@@ -1048,3 +1051,119 @@ class CheckSpatialSheetTests(TestCase):
             self.assertEqual(check_spatial_sheet(path), [])
         finally:
             _cleanup(path)
+
+
+# ---------------------------------------------------------------------------
+# BrainInitiative
+# ---------------------------------------------------------------------------
+
+class BrainInitiativeTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user('testuser', password='testpass')
+        self.client.login(username='testuser', password='testpass')
+        self.people = People.objects.create(
+            name='Test User',
+            orcid='',
+            affiliation='',
+            affiliation_identifier='',
+            is_bil_admin=False,
+            has_reviewed_brain_initiative=False,
+            auth_user_id=self.user,
+        )
+        self.project = Project.objects.create(
+            name='Test Project',
+            funded_by='NIH',
+            is_brain_initiative=False,
+        )
+        ProjectPeople.objects.create(
+            project_id=self.project,
+            people_id=self.people,
+            is_pi=True,
+            is_po=False,
+            doi_role='creator',
+        )
+
+    def test_create_project_sets_brain_initiative_true(self):
+        payload = [{'name': 'New Proj', 'funded_by': 'NIH', 'consortia_ids': [], 'parent_project': '', 'is_brain_initiative': True}]
+        response = self.client.post(
+            '/ingest/create_project/',
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        proj = Project.objects.get(name='New Proj')
+        self.assertTrue(proj.is_brain_initiative)
+
+    def test_create_project_sets_brain_initiative_false_by_default(self):
+        payload = [{'name': 'No BI Proj', 'funded_by': '', 'consortia_ids': [], 'parent_project': '', 'is_brain_initiative': False}]
+        response = self.client.post(
+            '/ingest/create_project/',
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        proj = Project.objects.get(name='No BI Proj')
+        self.assertFalse(proj.is_brain_initiative)
+
+    def test_review_brain_initiative_saves_and_sets_flag(self):
+        payload = {str(self.project.id): True}
+        response = self.client.post(
+            '/ingest/review-brain-initiative/',
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'success': True})
+        self.people.refresh_from_db()
+        self.assertTrue(self.people.has_reviewed_brain_initiative)
+        self.project.refresh_from_db()
+        self.assertTrue(self.project.is_brain_initiative)
+
+    def test_review_brain_initiative_ignores_unowned_projects(self):
+        other_project = Project.objects.create(name='Other', funded_by='')
+        payload = {str(other_project.id): True}
+        response = self.client.post(
+            '/ingest/review-brain-initiative/',
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        other_project.refresh_from_db()
+        self.assertFalse(other_project.is_brain_initiative)
+        self.people.refresh_from_db()
+        self.assertTrue(self.people.has_reviewed_brain_initiative)
+
+    def test_toggle_brain_initiative_on(self):
+        response = self.client.post(
+            f'/ingest/toggle-brain-initiative/{self.project.id}/',
+            data=json.dumps({'is_brain_initiative': True}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'success': True})
+        self.project.refresh_from_db()
+        self.assertTrue(self.project.is_brain_initiative)
+
+    def test_toggle_brain_initiative_off(self):
+        self.project.is_brain_initiative = True
+        self.project.save()
+        response = self.client.post(
+            f'/ingest/toggle-brain-initiative/{self.project.id}/',
+            data=json.dumps({'is_brain_initiative': False}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.project.refresh_from_db()
+        self.assertFalse(self.project.is_brain_initiative)
+
+    def test_toggle_brain_initiative_unauthorized(self):
+        other_project = Project.objects.create(name='Other', funded_by='')
+        response = self.client.post(
+            f'/ingest/toggle-brain-initiative/{other_project.id}/',
+            data=json.dumps({'is_brain_initiative': True}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 403)
+        other_project.refresh_from_db()
+        self.assertFalse(other_project.is_brain_initiative)

--- a/ingest/urls.py
+++ b/ingest/urls.py
@@ -58,4 +58,6 @@ urlpatterns = [
     path("refresh_tables/", views.refresh_tables, name="refresh_tables"),
     path("doi_api/", views.doi_api, name="doi_api"),
     path('ingest/metadata_errors/<int:associated_collection>/', views.metadata_error_view, name='metadata_error_view'),
+    path('review-brain-initiative/', views.review_brain_initiative, name='review_brain_initiative'),
+    path('toggle-brain-initiative/<int:pk>/', views.toggle_brain_initiative, name='toggle_brain_initiative'),
 ]

--- a/ingest/views.py
+++ b/ingest/views.py
@@ -48,84 +48,52 @@ from django.db.models import OuterRef, Subquery, Q, Exists, Count, F, Sum
 from django.db.models.functions import ExtractYear
 from pathlib import Path
 import jwt, time
+import concurrent.futures
 import brainimagelibrary
 
 
-def _get_public_dataset_stats():
-    """Return (public_dataset_count, public_file_count, datasets_by_year).
+def _sdk_fetch_report():
+    from brainimagelibrary import reports as bil_reports
+    return bil_reports.daily()
 
-    All stats come from brainimagelibrary.summary.daily() (dict response).
-    Falls back to local ORM if the SDK call fails.
-    Results are cached for 1 hour.
+
+def _get_public_dataset_stats():
+    """Return (public_dataset_count, public_file_count, datasets_by_year) or None.
+
+    All three values are derived from the same SDK DataFrame so the bar chart
+    always sums to the headline count. Returns None (hides the section) if the
+    SDK is unavailable or takes too long.
     """
     cached = cache.get('public_dataset_stats')
     if cached is not None:
         return cached
 
-    # --- Per-year breakdown from ORM (always, for the bar chart) ---
-    _latest_sheet_subq = Subquery(
-        Sheet.objects.filter(
-            collection_id=OuterRef('collection_id'),
-        ).order_by('-date_uploaded').values('id')[:1]
-    )
-    latest_sheet_ids = (
-        Sheet.objects
-        .filter(collection__submission_status='SUCCESS',
-                collection__validation_status='SUCCESS')
-        .annotate(latest_id=_latest_sheet_subq)
-        .filter(latest_id=F('id'))
-        .values_list('id', flat=True)
-    )
-    upgraded_v1_ids = BIL_ID.objects.filter(
-        v1_ds_id__isnull=False, v2_ds_id__isnull=False,
-    ).values_list('v1_ds_id', flat=True)
-    v2_by_year = (
-        Dataset.objects.filter(sheet_id__in=latest_sheet_ids)
-        .annotate(year=ExtractYear('sheet__date_uploaded'))
-        .values('year').annotate(n=Count('id')).order_by('year')
-    )
-    v1_by_year = (
-        DescriptiveMetadata.objects
-        .filter(collection__submission_status='SUCCESS',
-                collection__validation_status='SUCCESS')
-        .exclude(id__in=upgraded_v1_ids)
-        .annotate(year=ExtractYear('date_created'))
-        .values('year').annotate(n=Count('id')).order_by('year')
-    )
-    year_map = {}
-    for row in v2_by_year:
-        if row['year']:
-            year_map[row['year']] = year_map.get(row['year'], 0) + row['n']
-    for row in v1_by_year:
-        if row['year']:
-            year_map[row['year']] = year_map.get(row['year'], 0) + row['n']
-    datasets_by_year = [{'year': y, 'count': year_map[y]} for y in sorted(year_map)]
-
-    # --- Dataset count + file count from SDK ---
+    # Enforce a hard timeout — the SDK has an internal scratch-build fallback
+    # that can run for minutes. We avoid the `with` context manager because its
+    # __exit__ calls shutdown(wait=True) and would block until the thread finishes.
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
     try:
-        data = brainimagelibrary.summary.daily()
-        if data and isinstance(data, dict):
-            public_dataset_count = int(data.get('number_of_datasets', 0))
-            public_file_count = int(data.get('number_of_files', 0))
-            result = (public_dataset_count, public_file_count, datasets_by_year)
-            cache.set('public_dataset_stats', result, 3600)
-            return result
+        future = executor.submit(_sdk_fetch_report)
+        df = future.result(timeout=5)
     except Exception:
-        pass
+        executor.shutdown(wait=False)
+        return None
+    executor.shutdown(wait=False)
 
-    # --- ORM fallback for dataset count + file count ---
-    public_file_count = (
-        Dataset.objects
-        .filter(sheet_id__in=latest_sheet_ids, number_of_files__isnull=False)
-        .aggregate(total=Sum('number_of_files'))['total'] or 0
-    )
-    v2_count = Dataset.objects.filter(sheet_id__in=latest_sheet_ids).count()
-    v1_count = DescriptiveMetadata.objects.filter(
-        collection__submission_status='SUCCESS',
-        collection__validation_status='SUCCESS',
-    ).exclude(id__in=upgraded_v1_ids).count()
-    public_dataset_count = v2_count + v1_count
-    return (public_dataset_count, public_file_count, datasets_by_year)
+    if df is None or df.empty:
+        return None
+
+    public_dataset_count = len(df)
+    public_file_count = int(df['number_of_files'].sum())
+
+    df_dated = df.dropna(subset=['bildate']).copy()
+    df_dated['year'] = df_dated['bildate'].str[:4].astype(int)
+    year_counts = df_dated.groupby('year').size().sort_index()
+    datasets_by_year = [{'year': int(y), 'count': int(c)} for y, c in year_counts.items()]
+
+    result = (public_dataset_count, public_file_count, datasets_by_year)
+    cache.set('public_dataset_stats', result, 3600)
+    return result
 
 
 def logout(request):
@@ -158,6 +126,7 @@ def index(request):
         people.affiliation = ''
         people.affiliation_identifier = ''
         people.is_bil_admin = False
+        people.has_reviewed_brain_initiative = True
         people.auth_user_id = current_user
         people.save()
 
@@ -185,7 +154,14 @@ def index(request):
     )
 
     # --- Step 3: Routing logic based on role ---
-    public_dataset_count, public_file_count, datasets_by_year = _get_public_dataset_stats()
+    _stats = _get_public_dataset_stats()
+    if _stats is not None:
+        public_dataset_count, public_file_count, datasets_by_year = _stats
+        show_stats = True
+    else:
+        public_dataset_count = public_file_count = 0
+        datasets_by_year = []
+        show_stats = False
 
     # User contribution stats
     user_public_collections = Collection.objects.filter(
@@ -213,20 +189,36 @@ def index(request):
                 'public_dataset_count': public_dataset_count,
                 'public_file_count': public_file_count,
                 'datasets_by_year': datasets_by_year,
+                'show_stats': show_stats,
                 'user_public_collections': user_public_collections,
                 'user_public_datasets': user_public_datasets,
                 'user_validation_requested': user_validation_requested,
             })
+        pi_attribute = None
+        pi_projects = []
         for attribute in project_person:
             if attribute.is_pi:
-                return render(request, 'ingest/pi_index.html', {
-                    'project_person': attribute,
-                    'public_dataset_count': public_dataset_count,
-                    'public_file_count': public_file_count,
-                    'datasets_by_year': datasets_by_year,
-                    'user_public_collections': user_public_collections,
-                    'user_public_datasets': user_public_datasets,
+                if pi_attribute is None:
+                    pi_attribute = attribute
+                proj = Project.objects.get(id=attribute.project_id_id)
+                pi_projects.append({
+                    'id': proj.id,
+                    'name': proj.name,
+                    'is_brain_initiative': proj.is_brain_initiative,
                 })
+
+        if pi_attribute is not None:
+            return render(request, 'ingest/pi_index.html', {
+                'project_person': pi_attribute,
+                'public_dataset_count': public_dataset_count,
+                'public_file_count': public_file_count,
+                'datasets_by_year': datasets_by_year,
+                'show_stats': show_stats,
+                'user_public_collections': user_public_collections,
+                'user_public_datasets': user_public_datasets,
+                'show_brain_initiative_modal': not people.has_reviewed_brain_initiative,
+                'pi_projects': pi_projects,
+            })
     except Exception as e:
         print(e)
 
@@ -234,6 +226,7 @@ def index(request):
         'public_dataset_count': public_dataset_count,
         'public_file_count': public_file_count,
         'datasets_by_year': datasets_by_year,
+        'show_stats': show_stats,
         'user_public_collections': user_public_collections,
         'user_public_datasets': user_public_datasets,
     })
@@ -460,9 +453,10 @@ def create_project(request):
         name = item['name']
         consortia_ids = item['consortia_ids']
         parent_project = item['parent_project']
+        is_brain_initiative = item.get('is_brain_initiative', False)
 
-        # write project to the project table   
-        project = Project(funded_by=funded_by, name=name)
+        # write project to the project table
+        project = Project(funded_by=funded_by, name=name, is_brain_initiative=is_brain_initiative)
         project.save()
         save_project_id(project)
         proj_id = project.id
@@ -483,8 +477,68 @@ def create_project(request):
         
         project_person = ProjectPeople(project_id_id=project_id_id, people_id_id=person.id, is_pi=True, is_po=False, doi_role='creator')
         project_person.save()
-    messages.success(request, 'Project Created!')    
+    messages.success(request, 'Project Created!')
     return HttpResponse(json.dumps({'url': reverse('ingest:manage_projects')}))
+
+
+@login_required
+def review_brain_initiative(request):
+    if request.method != 'POST':
+        return JsonResponse({'error': 'Method not allowed'}, status=405, headers={'Allow': 'POST'})
+
+    current_user = request.user
+    try:
+        people = People.objects.get(auth_user_id_id=current_user.id)
+    except People.DoesNotExist:
+        return JsonResponse({'error': 'User profile not found'}, status=404)
+    owned_ids = set(
+        ProjectPeople.objects
+        .filter(people_id=people.id, is_pi=True)
+        .values_list('project_id_id', flat=True)
+    )
+
+    try:
+        data = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({'error': 'Invalid JSON'}, status=400)
+
+    for project_id_str, value in data.items():
+        try:
+            project_id = int(project_id_str)
+        except (ValueError, TypeError):
+            continue
+        if project_id in owned_ids:
+            Project.objects.filter(id=project_id).update(is_brain_initiative=bool(value))
+
+    people.has_reviewed_brain_initiative = True
+    people.save()
+    return JsonResponse({'success': True})
+
+
+@login_required
+def toggle_brain_initiative(request, pk):
+    if request.method != 'POST':
+        return JsonResponse({'error': 'Method not allowed'}, status=405, headers={'Allow': 'POST'})
+
+    current_user = request.user
+    try:
+        people = People.objects.get(auth_user_id_id=current_user.id)
+    except People.DoesNotExist:
+        return JsonResponse({'error': 'User profile not found'}, status=404)
+
+    if not ProjectPeople.objects.filter(people_id=people.id, project_id_id=pk, is_pi=True).exists():
+        return JsonResponse({'error': 'Not authorized'}, status=403)
+
+    try:
+        data = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({'error': 'Invalid JSON'}, status=400)
+
+    value = data.get('is_brain_initiative')
+    if not isinstance(value, bool):
+        return JsonResponse({'error': 'Invalid value'}, status=400)
+    Project.objects.filter(id=pk).update(is_brain_initiative=value)
+    return JsonResponse({'success': True})
 
 
 @login_required
@@ -923,7 +977,8 @@ def check_collection_directories(coll, current_user):
     datasets = Dataset.objects.filter(sheet__collection=coll)
     expected_dirs = sorted([
         Path(ds.bildirectory).name.strip("/")
-        for ds in datasets if ds.bildirectory
+        for ds in datasets
+        if ds.bildirectory and Path(ds.bildirectory).resolve() != base_dir.resolve()
     ])
 
     missing = [d for d in expected_dirs if d not in actual_dirs]


### PR DESCRIPTION
  - adds is_brain_initiative to Project and has_reviewed_brain_initiative to People                                       
  - surfaces a one-time brain initiative modal for PIs on dashboard load
  - sources homepage stats exclusively from the SDK DataFrame so chart                                                    
    totals always match headline counts
  - hides the stats section entirely if the SDK is unavailable or slow                                                    
    rather than blocking on a slow ORM fallback build"